### PR TITLE
Give proper api name for ChannelCredentials certificate byte list

### DIFF
--- a/interop/lib/src/client.dart
+++ b/interop/lib/src/client.dart
@@ -96,7 +96,7 @@ class Tester {
         trustedRoot = File('ca.pem').readAsBytesSync();
       }
       credentials = ChannelCredentials.secure(
-          certificates: trustedRoot, authority: serverHostOverride);
+          certificateBytes: trustedRoot, authority: serverHostOverride);
     } else {
       credentials = const ChannelCredentials.insecure();
     }

--- a/lib/src/client/transport/http2_credentials.dart
+++ b/lib/src/client/transport/http2_credentials.dart
@@ -44,14 +44,14 @@ class ChannelCredentials {
   const ChannelCredentials.insecure({String authority})
       : this._(false, null, null, authority, null);
 
-  /// Enable TLS and optionally specify the [certificates] to trust. If
-  /// [certificates] is not provided, the default trust store is used.
+  /// Enable TLS and optionally specify the [certificatesBytes] for the certifcate
+  ///  to trust. If [certificatesBytes] is not provided, the default trust store is used.
   const ChannelCredentials.secure(
-      {List<int> certificates,
+      {List<int> certificateBytes,
       String password,
       String authority,
       BadCertificateHandler onBadCertificate})
-      : this._(true, certificates, password, authority, onBadCertificate);
+      : this._(true, certificateBytes, password, authority, onBadCertificate);
 
   SecurityContext get securityContext {
     if (!isSecure) return null;

--- a/test/options_test.dart
+++ b/test/options_test.dart
@@ -23,18 +23,19 @@ const isTlsException = TypeMatcher<TlsException>();
 void main() {
   group('Certificates', () {
     test('report password errors correctly', () async {
-      final certificates = await File('test/data/certstore.p12').readAsBytes();
+      final certificateBytes =
+          await File('test/data/certstore.p12').readAsBytes();
 
       final missingPassword =
-          ChannelCredentials.secure(certificates: certificates);
+          ChannelCredentials.secure(certificateBytes: certificateBytes);
       expect(() => missingPassword.securityContext, throwsA(isTlsException));
 
       final wrongPassword = ChannelCredentials.secure(
-          certificates: certificates, password: 'wrong');
+          certificateBytes: certificateBytes, password: 'wrong');
       expect(() => wrongPassword.securityContext, throwsA(isTlsException));
 
       final correctPassword = ChannelCredentials.secure(
-          certificates: certificates, password: 'correct');
+          certificateBytes: certificateBytes, password: 'correct');
       expect(correctPassword.securityContext, isNotNull);
     });
   });

--- a/test/round_trip_test.dart
+++ b/test/round_trip_test.dart
@@ -74,7 +74,8 @@ main() async {
       server.port,
       ChannelOptions(
           credentials: ChannelCredentials.secure(
-              certificates: File('test/data/localhost.crt').readAsBytesSync(),
+              certificateBytes:
+                  File('test/data/localhost.crt').readAsBytesSync(),
               authority: 'localhost')),
     ));
     final testClient = TestClient(channel);


### PR DESCRIPTION
`certificates` is a confusing name for a `List<int>` intended to hold the bytes for a single certificate, so renaming this property to `certificateBytes`.